### PR TITLE
CSS fileok a repoban

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-*.css
 .sass-cache
 !lib/bootstrap/css/*.css
 !css/flexslider.css

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,74 @@
+/*
+Syntax error: Invalid CSS after "...nd (max-width: ": expected expression (e.g. 1px, bold), was "$screen-compact..."
+        on line 47 of /Volumes/HDD/Users/aboros/Sites/dhu.template.local/sass/_layout.scss
+        from line 4 of /Volumes/HDD/Users/aboros/Sites/dhu.template.local/sass/style.scss
+
+Backtrace:
+/Volumes/HDD/Users/aboros/Sites/dhu.template.local/sass/_layout.scss:47
+/Volumes/HDD/Users/aboros/Sites/dhu.template.local/sass/style.scss:4
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/scss/parser.rb:926:in `expected'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/scss/parser.rb:872:in `expected'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/scss/parser.rb:854:in `expr!'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/scss/parser.rb:332:in `media_expr'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/scss/parser.rb:853:in `send'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/scss/parser.rb:853:in `expr!'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/scss/parser.rb:318:in `media_query'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/scss/parser.rb:296:in `media_query_list'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/scss/parser.rb:290:in `media_directive'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/scss/parser.rb:787:in `str'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/scss/parser.rb:290:in `media_directive'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/scss/parser.rb:146:in `send'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/scss/parser.rb:146:in `special_directive'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/scss/parser.rb:125:in `directive'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/scss/parser.rb:395:in `block_child'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/scss/parser.rb:388:in `block_contents'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/scss/parser.rb:59:in `stylesheet'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/scss/parser.rb:28:in `parse'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/engine.rb:327:in `_to_tree'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/engine.rb:259:in `to_tree'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/tree/visitors/perform.rb:142:in `visit_import'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/tree/visitors/base.rb:37:in `send'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/tree/visitors/base.rb:37:in `visit'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/tree/visitors/perform.rb:18:in `visit'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/tree/visitors/base.rb:53:in `visit_children'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/tree/visitors/base.rb:53:in `map'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/tree/visitors/base.rb:53:in `visit_children'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/tree/visitors/perform.rb:27:in `visit_children'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/tree/visitors/perform.rb:39:in `with_environment'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/tree/visitors/perform.rb:26:in `visit_children'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/tree/visitors/base.rb:37:in `visit'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/tree/visitors/perform.rb:47:in `visit_root'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/tree/visitors/base.rb:37:in `send'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/tree/visitors/base.rb:37:in `visit'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/tree/visitors/perform.rb:18:in `visit'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/tree/visitors/perform.rb:7:in `send'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/tree/visitors/perform.rb:7:in `visit'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/tree/root_node.rb:20:in `render'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/engine.rb:300:in `_render'
+/Library/Ruby/Gems/1.8/gems/sass-3.1.11/lib/sass/../sass/engine.rb:247:in `render'
+/Library/Ruby/Gems/1.8/gems/compass-0.12.1/lib/compass/compiler.rb:140:in `compile'
+/Library/Ruby/Gems/1.8/gems/compass-0.12.1/lib/compass/compiler.rb:126:in `timed'
+/Library/Ruby/Gems/1.8/gems/compass-0.12.1/lib/compass/compiler.rb:139:in `compile'
+/Library/Ruby/Gems/1.8/gems/compass-0.12.1/lib/compass/logger.rb:45:in `red'
+/Library/Ruby/Gems/1.8/gems/compass-0.12.1/lib/compass/compiler.rb:138:in `compile'
+/Library/Ruby/Gems/1.8/gems/compass-0.12.1/lib/compass/compiler.rb:118:in `compile_if_required'
+/Library/Ruby/Gems/1.8/gems/compass-0.12.1/lib/compass/compiler.rb:103:in `run'
+/Library/Ruby/Gems/1.8/gems/compass-0.12.1/lib/compass/compiler.rb:101:in `each'
+/Library/Ruby/Gems/1.8/gems/compass-0.12.1/lib/compass/compiler.rb:101:in `run'
+/Library/Ruby/Gems/1.8/gems/compass-0.12.1/lib/compass/compiler.rb:126:in `timed'
+/Library/Ruby/Gems/1.8/gems/compass-0.12.1/lib/compass/compiler.rb:100:in `run'
+/Library/Ruby/Gems/1.8/gems/compass-0.12.1/lib/compass/commands/update_project.rb:45:in `perform'
+/Library/Ruby/Gems/1.8/gems/compass-0.12.1/lib/compass/commands/base.rb:18:in `execute'
+/Library/Ruby/Gems/1.8/gems/compass-0.12.1/lib/compass/commands/project_base.rb:19:in `execute'
+/Library/Ruby/Gems/1.8/gems/compass-0.12.1/lib/compass/exec/sub_command_ui.rb:43:in `perform!'
+/Library/Ruby/Gems/1.8/gems/compass-0.12.1/lib/compass/exec/sub_command_ui.rb:15:in `run!'
+/Library/Ruby/Gems/1.8/gems/compass-0.12.1/bin/compass:29
+/Library/Ruby/Gems/1.8/gems/compass-0.12.1/bin/compass:43:in `call'
+/Library/Ruby/Gems/1.8/gems/compass-0.12.1/bin/compass:43
+/usr/bin/compass:19:in `load'
+/usr/bin/compass:19
+*/
+body:before {
+  white-space: pre;
+  font-family: monospace;
+  content: "Syntax error: Invalid CSS after \"...nd (max-width: \": expected expression (e.g. 1px, bold), was \"$screen-compact...\"\A         on line 47 of /Volumes/HDD/Users/aboros/Sites/dhu.template.local/sass/_layout.scss\A         from line 4 of /Volumes/HDD/Users/aboros/Sites/dhu.template.local/sass/style.scss"; }


### PR DESCRIPTION
Nem voltak CSS fileok a repoban, a .gitignore *.css sorral kezdődött. Ez azért probléma, mert így nem tudjuk megmutatni a munka eredményét a github pages segítségével.

Ez eltávolítja az inkriminált sort a .gitignore -ból és hozzáadja a jelenlegi állapot CSS -ét, amit compass compile parancssal generáltam.
